### PR TITLE
Fix insights-simple page not showing content

### DIFF
--- a/src/pages/InsightsPage.tsx
+++ b/src/pages/InsightsPage.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUsageTracking } from "@/hooks/useUsageTracking";
+import { Brain } from "lucide-react";
 
 // Light Platform Styling
 const dashboardStyles = `


### PR DESCRIPTION
Add missing import for Brain icon to fix blank insights-simple page.

---
<a href="https://cursor.com/background-agent?bcId=bc-388761e8-791f-495d-977c-cf57796a223f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-388761e8-791f-495d-977c-cf57796a223f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

