### PR TITLE
Update insights simple with ai analysis

### DIFF
--- a/src/pages/InsightsSimplePage.tsx
+++ b/src/pages/InsightsSimplePage.tsx
@@ -240,9 +240,9 @@ const InsightsSimplePage: React.FC = () => {
           if (response.status === 401) {
             console.error('🔑 Authentication failed. Check JWT token.');
           } else if (response.status === 404) {
-            console.error('🔧 Function not found. Check if Edge Function is deployed.');
+            console.error('🔧 Function not found. Check if analyze-insights Edge Function is deployed.');
           } else if (response.status === 500) {
-            console.error('🔧 Server error. Check Edge Function logs.');
+            console.error('🔧 Server error. Check analyze-insights Edge Function logs.');
           }
           
           throw new Error(`Edge Function failed: ${response.status} ${errorText}`);
@@ -259,6 +259,8 @@ const InsightsSimplePage: React.FC = () => {
       throw error;
     }
   };
+
+
 
   // Generate mock analysis for testing when Edge Function is not available
   const generateMockAnalysis = (data: any, fileType: string): GeminiAnalysis => {
@@ -293,7 +295,7 @@ const InsightsSimplePage: React.FC = () => {
           "Processing efficiency: 92%",
           "Analysis accuracy: 88%",
           "Recommendation relevance: 90%"
-        ],
+          ],
         score: 87
       },
       sentiment: {


### PR DESCRIPTION
Update error messages for Edge Function failures to specifically mention the `analyze-insights` function.

The `/insights-simple` page was showing mock analysis results because the `analyze-insights` Edge Function was not deployed. These changes clarify the error messages displayed in the console when the function is not found or encounters a server error, aiding in debugging the deployment status.

---
<a href="https://cursor.com/background-agent?bcId=bc-b176c821-6da1-479a-81d1-80fe466c53b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b176c821-6da1-479a-81d1-80fe466c53b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

