### PR TITLE
Fix billing profile updated_at column error

### DIFF
--- a/src/hooks/useBillingSystem.ts
+++ b/src/hooks/useBillingSystem.ts
@@ -471,8 +471,7 @@ export function useBillingSystem(): BillingSystemState {
       const { error: updateError } = await supabase
         .from('billing_profiles')
         .update({
-          subscription_status: 'cancelled',
-          updated_at: new Date().toISOString()
+          subscription_status: 'cancelled'
         })
         .eq('id', billingProfile?.id);
 


### PR DESCRIPTION
Remove `updated_at` from `billing_profiles` update to fix 'column not found' error during subscription cancellation.

---
<a href="https://cursor.com/background-agent?bcId=bc-b76e4f75-d124-4b9b-b103-f1fa3a6e1d90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b76e4f75-d124-4b9b-b103-f1fa3a6e1d90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

