### PR TITLE
Handle existing policy for billing profiles

### DIFF
--- a/fix-auth-db-error.sql
+++ b/fix-auth-db-error.sql
@@ -36,14 +36,32 @@ ALTER TABLE billing_profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE usage_tracking ENABLE ROW LEVEL SECURITY;
 ALTER TABLE feedback_settings ENABLE ROW LEVEL SECURITY;
 
--- Create basic policies
-CREATE POLICY "users can read own billing profile" ON billing_profiles FOR SELECT USING (auth.uid() = id);
-CREATE POLICY "users can insert own billing profile" ON billing_profiles FOR INSERT WITH CHECK (auth.uid() = id);
+-- Create basic policies safely
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'billing_profiles' AND policyname = 'users can read own billing profile') THEN
+    CREATE POLICY "users can read own billing profile" ON billing_profiles FOR SELECT USING (auth.uid() = id);
+  END IF;
+  
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'billing_profiles' AND policyname = 'users can insert own billing profile') THEN
+    CREATE POLICY "users can insert own billing profile" ON billing_profiles FOR INSERT WITH CHECK (auth.uid() = id);
+  END IF;
 
-CREATE POLICY "users can read own usage" ON usage_tracking FOR SELECT USING (auth.uid() = user_id);
-CREATE POLICY "users can insert own usage" ON usage_tracking FOR INSERT WITH CHECK (auth.uid() = user_id);
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'usage_tracking' AND policyname = 'users can read own usage') THEN
+    CREATE POLICY "users can read own usage" ON usage_tracking FOR SELECT USING (auth.uid() = user_id);
+  END IF;
+  
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'usage_tracking' AND policyname = 'users can insert own usage') THEN
+    CREATE POLICY "users can insert own usage" ON usage_tracking FOR INSERT WITH CHECK (auth.uid() = user_id);
+  END IF;
 
-CREATE POLICY "users can read own feedback settings" ON feedback_settings FOR SELECT USING (auth.uid() = user_id);
-CREATE POLICY "users can insert own feedback settings" ON feedback_settings FOR INSERT WITH CHECK (auth.uid() = user_id);
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'feedback_settings' AND policyname = 'users can read own feedback settings') THEN
+    CREATE POLICY "users can read own feedback settings" ON feedback_settings FOR SELECT USING (auth.uid() = user_id);
+  END IF;
+  
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'feedback_settings' AND policyname = 'users can insert own feedback settings') THEN
+    CREATE POLICY "users can insert own feedback settings" ON feedback_settings FOR INSERT WITH CHECK (auth.uid() = user_id);
+  END IF;
+END $$;
 
 SELECT 'Database fix completed - user creation should now work!' as status;

--- a/supabase/migrations/20250121000000_create_billing_profiles.sql
+++ b/supabase/migrations/20250121000000_create_billing_profiles.sql
@@ -36,26 +36,42 @@ ALTER TABLE billing_profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE transactions ENABLE ROW LEVEL SECURITY;
 
 -- RLS Policies for billing_profiles
-CREATE POLICY "users can read own billing profile"
-  ON billing_profiles FOR SELECT
-  USING (auth.uid() = id);
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'billing_profiles' AND policyname = 'users can read own billing profile') THEN
+    CREATE POLICY "users can read own billing profile"
+      ON billing_profiles FOR SELECT
+      USING (auth.uid() = id);
+  END IF;
 
-CREATE POLICY "users can update own billing profile"
-  ON billing_profiles FOR UPDATE
-  USING (auth.uid() = id);
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'billing_profiles' AND policyname = 'users can update own billing profile') THEN
+    CREATE POLICY "users can update own billing profile"
+      ON billing_profiles FOR UPDATE
+      USING (auth.uid() = id);
+  END IF;
 
-CREATE POLICY "users can insert own billing profile"
-  ON billing_profiles FOR INSERT
-  WITH CHECK (auth.uid() = id);
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'billing_profiles' AND policyname = 'users can insert own billing profile') THEN
+    CREATE POLICY "users can insert own billing profile"
+      ON billing_profiles FOR INSERT
+      WITH CHECK (auth.uid() = id);
+  END IF;
+END $$;
 
 -- RLS Policies for transactions
-CREATE POLICY "users can read own transactions"
-  ON transactions FOR SELECT
-  USING (auth.uid() = user_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'transactions' AND policyname = 'users can read own transactions') THEN
+    CREATE POLICY "users can read own transactions"
+      ON transactions FOR SELECT
+      USING (auth.uid() = user_id);
+  END IF;
 
-CREATE POLICY "users can insert own transactions"
-  ON transactions FOR INSERT
-  WITH CHECK (auth.uid() = user_id);
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'transactions' AND policyname = 'users can insert own transactions') THEN
+    CREATE POLICY "users can insert own transactions"
+      ON transactions FOR INSERT
+      WITH CHECK (auth.uid() = user_id);
+  END IF;
+END $$;
 
 -- Function to create billing profile for new users
 CREATE OR REPLACE FUNCTION create_billing_profile()


### PR DESCRIPTION
Make RLS policy creation idempotent to prevent "policy already exists" errors.

This change modifies SQL migration files to check for the existence of Row Level Security policies before attempting to create them. This resolves conflicts that arise when multiple migration files or repeated runs try to define the same policies, which previously caused `ERROR: 42710: policy "..." already exists`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8dd3d6e-2291-44e8-abd0-23fe0a026bdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8dd3d6e-2291-44e8-abd0-23fe0a026bdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

