### PR TITLE
Fix missing column in user plan query

### DIFF
--- a/supabase/migrations/20250120000000_create_billing_system.sql
+++ b/supabase/migrations/20250120000000_create_billing_system.sql
@@ -111,7 +111,6 @@ SELECT
     'Free',
     'active'
 FROM users u
-WHERE u.plan = 'free' OR u.plan IS NULL
 ON CONFLICT (user_id) DO NOTHING;
 
 -- Update existing users to have trial_end if not set

--- a/supabase/migrations/20250121000000_create_billing_profiles.sql
+++ b/supabase/migrations/20250121000000_create_billing_profiles.sql
@@ -120,8 +120,6 @@ INSERT INTO billing_profiles (id, plan, trial_ends_at, subscription_status)
 SELECT 
   u.id,
   CASE 
-    WHEN u.plan = 'pro' THEN 'pro'
-    WHEN u.plan = 'business' THEN 'business'
     WHEN u.created_at > NOW() - INTERVAL '8 days' THEN 'trial'
     ELSE 'free'
   END,
@@ -130,7 +128,6 @@ SELECT
     ELSE NULL
   END,
   CASE 
-    WHEN u.subscription_status = 'active' THEN 'active'
     WHEN u.created_at > NOW() - INTERVAL '8 days' THEN 'trial'
     ELSE 'expired'
   END


### PR DESCRIPTION
Remove references to non-existent `plan` and `subscription_status` columns from `auth.users` in billing migration files to fix database errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc1bb5bd-cac4-4424-9080-bab7215842d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc1bb5bd-cac4-4424-9080-bab7215842d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

