### PR TITLE
Fix payment verification and SQL enum error

### DIFF
--- a/src/components/PaystackPayment.tsx
+++ b/src/components/PaystackPayment.tsx
@@ -203,11 +203,30 @@ const PaystackPayment: React.FC<PaystackPaymentProps> = ({
       });
 
       if (!subscriptionResponse.ok) {
-        const error = await subscriptionResponse.json();
+        let error;
+        try {
+          const errorText = await subscriptionResponse.text();
+          if (errorText) {
+            error = JSON.parse(errorText);
+          } else {
+            error = { message: 'Empty response from server' };
+          }
+        } catch (parseError) {
+          error = { message: 'Failed to parse server response' };
+        }
         throw new Error(error.message || 'Failed to create subscription');
       }
 
-      const result = await subscriptionResponse.json();
+      let result;
+      try {
+        const responseText = await subscriptionResponse.text();
+        if (!responseText) {
+          throw new Error('Empty response from server');
+        }
+        result = JSON.parse(responseText);
+      } catch (parseError) {
+        throw new Error('Failed to parse server response');
+      }
 
       if (result.success) {
         toast.success(`🎉 Welcome to ${planName}! Your subscription has been activated.`);

--- a/supabase/functions/verify-payment/index.ts
+++ b/supabase/functions/verify-payment/index.ts
@@ -25,12 +25,26 @@ serve(async (req) => {
     }
 
     // Get request body
-    const { reference, plan, amount, email } = await req.json()
+    let body;
+    try {
+      body = await req.json();
+    } catch (error) {
+      console.error('Failed to parse request body:', error);
+      return new Response(
+        JSON.stringify({ error: 'Invalid JSON in request body' }),
+        { 
+          status: 400, 
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+        }
+      )
+    }
+
+    const { reference, plan, amount, email } = body;
 
     // Validate required fields
     if (!reference || !plan || !amount || !email) {
       return new Response(
-        JSON.stringify({ error: 'Missing required fields' }),
+        JSON.stringify({ error: 'Missing required fields', received: { reference, plan, amount, email } }),
         { 
           status: 400, 
           headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
@@ -78,7 +92,24 @@ serve(async (req) => {
       )
     }
 
-    const paystackData = await paystackResponse.json()
+    let paystackData;
+    try {
+      const responseText = await paystackResponse.text();
+      if (!responseText) {
+        throw new Error('Empty response from Paystack');
+      }
+      paystackData = JSON.parse(responseText);
+    } catch (error) {
+      console.error('Failed to parse Paystack response:', error);
+      return new Response(
+        JSON.stringify({ error: 'Invalid response from Paystack', details: 'Failed to parse response' }),
+        { 
+          status: 500, 
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+        }
+      )
+    }
+    
     console.log('Paystack response:', JSON.stringify(paystackData, null, 2))
 
     if (paystackData.status === false) {

--- a/supabase/migrations/20250123000000_comprehensive_billing_system.sql
+++ b/supabase/migrations/20250123000000_comprehensive_billing_system.sql
@@ -2,11 +2,19 @@
 -- This migration implements the complete SaaS billing flow with Paystack integration
 
 -- ========== ENUMS ==========
-CREATE TYPE IF NOT EXISTS subscription_status AS ENUM (
-  'trialing', 'active', 'past_due', 'non_renewing', 'canceled', 'completed', 'attention'
-);
+DO $$ BEGIN
+    CREATE TYPE subscription_status AS ENUM (
+      'trialing', 'active', 'past_due', 'non_renewing', 'canceled', 'completed', 'attention'
+    );
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
 
-CREATE TYPE IF NOT EXISTS plan_tier AS ENUM ('free', 'pro', 'business');
+DO $$ BEGIN
+    CREATE TYPE plan_tier AS ENUM ('free', 'pro', 'business');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
 
 -- ========== PLANS TABLE ==========
 CREATE TABLE IF NOT EXISTS plans (


### PR DESCRIPTION
Fix SQL syntax error for `CREATE TYPE` statements and enhance JSON parsing error handling in payment verification to prevent 'Unexpected end of JSON input' errors.

The SQL error was due to PostgreSQL not supporting `IF NOT EXISTS` with `CREATE TYPE`, which is now handled by a `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN null; END $$;` block. The JSON parsing error occurred when `JSON.parse()` was called on empty or malformed responses, which is now mitigated by adding checks for response text and robust try-catch blocks in both client and server-side payment verification logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-77d2d1fa-06d2-429c-bb09-295be62ea315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-77d2d1fa-06d2-429c-bb09-295be62ea315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

