### PR TITLE
Fix payment authorization header error

### DIFF
--- a/src/hooks/useBillingEnforcement.ts
+++ b/src/hooks/useBillingEnforcement.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
 import {
   checkFeatureUsage,
   enforceUsageLimit,
@@ -266,10 +267,18 @@ export function useBillingEnforcementWithTracking(): UseBillingEnforcementReturn
 
       // If they can use it, track the usage via the usage API
       // This will increment the counter and enforce limits server-side
-      const response = await fetch('/api/usage', {
+      const { data: { session } } = await supabase.auth.getSession();
+      
+      if (!session) {
+        throw new Error('No active session found');
+      }
+
+      const supabaseUrl = (supabase as any).supabaseUrl;
+      const response = await fetch(`${supabaseUrl}/functions/v1/usage`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`,
         },
         body: JSON.stringify({ action: feature }),
       });


### PR DESCRIPTION
Fix "Missing authorization header" error by correctly authenticating usage tracking calls after payment.

The `useBillingEnforcementWithTracking` hook was incorrectly calling a local `/api/usage` endpoint without an authorization header. This PR updates the hook to call the Supabase Edge Function `/functions/v1/usage` with the user's session access token, ensuring proper authentication for usage tracking after a successful payment.

---
<a href="https://cursor.com/background-agent?bcId=bc-210ad5d7-f935-4e89-a3df-880f137f8c50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-210ad5d7-f935-4e89-a3df-880f137f8c50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

