### PR TITLE
Drop and recreate user status function

### DIFF
--- a/fix_get_user_status_return_type.sql
+++ b/fix_get_user_status_return_type.sql
@@ -1,0 +1,88 @@
+-- Fix get_user_status function return type issue
+-- This script drops the existing function and recreates it with the correct return type
+
+-- Step 1: Drop the existing function
+DROP FUNCTION IF EXISTS get_user_status(uuid);
+
+-- Step 2: Recreate the function with the correct return type
+CREATE OR REPLACE FUNCTION get_user_status(user_uuid UUID)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    user_profile RECORD;
+    calculated_trial_end TIMESTAMPTZ;
+    result JSON;
+BEGIN
+    -- Get user profile with all billing info
+    SELECT 
+        p.plan,
+        p.trial_start,
+        p.trial_end,
+        p.is_active,
+        p.created_at,
+        bp.subscription_status,
+        bp.paystack_customer_id,
+        bp.next_billing_date
+    INTO user_profile
+    FROM profiles p
+    LEFT JOIN billing_profiles bp ON bp.id = p.user_id
+    WHERE p.user_id = user_uuid;
+    
+    -- If no profile exists, create one with free trial
+    IF NOT FOUND THEN
+        INSERT INTO profiles (
+            user_id,
+            plan,
+            trial_start,
+            trial_end,
+            is_active
+        ) VALUES (
+            user_uuid,
+            'free_trial',
+            NOW(),
+            NOW() + INTERVAL '8 days',
+            TRUE
+        )
+        RETURNING plan, trial_start, trial_end, is_active, created_at
+        INTO user_profile.plan, user_profile.trial_start, user_profile.trial_end, user_profile.is_active, user_profile.created_at;
+        
+        -- Set default values for billing profile fields
+        user_profile.subscription_status := 'trial';
+        user_profile.paystack_customer_id := NULL;
+        user_profile.next_billing_date := NULL;
+    END IF;
+    
+    -- Calculate trial_end if it's NULL (for existing users)
+    calculated_trial_end := COALESCE(
+        user_profile.trial_end, 
+        user_profile.trial_start + INTERVAL '8 days'
+    );
+    
+    -- Build result JSON with proper NULL handling
+    result := json_build_object(
+        'plan', COALESCE(user_profile.plan, 'free_trial'),
+        'trial_start', COALESCE(user_profile.trial_start, user_profile.created_at),
+        'trial_end', calculated_trial_end,
+        'is_active', COALESCE(user_profile.is_active, TRUE),
+        'subscription_status', COALESCE(user_profile.subscription_status, 'trial'),
+        'paystack_customer_id', user_profile.paystack_customer_id,
+        'next_billing_date', user_profile.next_billing_date,
+        'trial_days_remaining', GREATEST(0, EXTRACT(days FROM (calculated_trial_end - NOW()))::INTEGER),
+        'is_trial_expired', COALESCE(calculated_trial_end < NOW(), FALSE),
+        'should_show_lock', (
+            (COALESCE(user_profile.plan, 'free_trial') = 'free_trial' AND COALESCE(calculated_trial_end < NOW(), FALSE)) OR
+            (COALESCE(user_profile.plan, 'free_trial') = 'business' AND COALESCE(user_profile.is_active, TRUE) = FALSE)
+        )
+    );
+    
+    RETURN result;
+END;
+$$;
+
+-- Step 3: Grant permissions
+GRANT EXECUTE ON FUNCTION get_user_status(UUID) TO authenticated;
+
+-- Step 4: Verify the function was created successfully
+SELECT 'get_user_status function recreated successfully' as status;

--- a/supabase/migrations/20250908215759_fix_get_user_status_return_type.sql
+++ b/supabase/migrations/20250908215759_fix_get_user_status_return_type.sql
@@ -1,0 +1,85 @@
+-- Fix get_user_status function return type issue
+-- This migration drops the existing function and recreates it to resolve the return type conflict
+
+-- Step 1: Drop the existing function
+DROP FUNCTION IF EXISTS get_user_status(uuid);
+
+-- Step 2: Recreate the function with the correct return type
+CREATE OR REPLACE FUNCTION get_user_status(user_uuid UUID)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    user_profile RECORD;
+    calculated_trial_end TIMESTAMPTZ;
+    result JSON;
+BEGIN
+    -- Get user profile with all billing info
+    SELECT 
+        p.plan,
+        p.trial_start,
+        p.trial_end,
+        p.is_active,
+        p.created_at,
+        bp.subscription_status,
+        bp.paystack_customer_id,
+        bp.next_billing_date
+    INTO user_profile
+    FROM profiles p
+    LEFT JOIN billing_profiles bp ON bp.id = p.user_id
+    WHERE p.user_id = user_uuid;
+    
+    -- If no profile exists, create one with free trial
+    IF NOT FOUND THEN
+        INSERT INTO profiles (
+            user_id,
+            plan,
+            trial_start,
+            trial_end,
+            is_active
+        ) VALUES (
+            user_uuid,
+            'free_trial',
+            NOW(),
+            NOW() + INTERVAL '8 days',
+            TRUE
+        )
+        RETURNING plan, trial_start, trial_end, is_active, created_at
+        INTO user_profile.plan, user_profile.trial_start, user_profile.trial_end, user_profile.is_active, user_profile.created_at;
+        
+        -- Set default values for billing profile fields
+        user_profile.subscription_status := 'trial';
+        user_profile.paystack_customer_id := NULL;
+        user_profile.next_billing_date := NULL;
+    END IF;
+    
+    -- Calculate trial_end if it's NULL (for existing users)
+    calculated_trial_end := COALESCE(
+        user_profile.trial_end, 
+        user_profile.trial_start + INTERVAL '8 days'
+    );
+    
+    -- Build result JSON with proper NULL handling
+    result := json_build_object(
+        'plan', COALESCE(user_profile.plan, 'free_trial'),
+        'trial_start', COALESCE(user_profile.trial_start, user_profile.created_at),
+        'trial_end', calculated_trial_end,
+        'is_active', COALESCE(user_profile.is_active, TRUE),
+        'subscription_status', COALESCE(user_profile.subscription_status, 'trial'),
+        'paystack_customer_id', user_profile.paystack_customer_id,
+        'next_billing_date', user_profile.next_billing_date,
+        'trial_days_remaining', GREATEST(0, EXTRACT(days FROM (calculated_trial_end - NOW()))::INTEGER),
+        'is_trial_expired', COALESCE(calculated_trial_end < NOW(), FALSE),
+        'should_show_lock', (
+            (COALESCE(user_profile.plan, 'free_trial') = 'free_trial' AND COALESCE(calculated_trial_end < NOW(), FALSE)) OR
+            (COALESCE(user_profile.plan, 'free_trial') = 'business' AND COALESCE(user_profile.is_active, TRUE) = FALSE)
+        )
+    );
+    
+    RETURN result;
+END;
+$$;
+
+-- Step 3: Grant permissions
+GRANT EXECUTE ON FUNCTION get_user_status(UUID) TO authenticated;


### PR DESCRIPTION
Drop and recreate `get_user_status` function to update its return type to JSON, resolving a PostgreSQL error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6654703-6fd0-45fe-bf5b-cd3208b9eeca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d6654703-6fd0-45fe-bf5b-cd3208b9eeca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

