### PR TITLE
Fix SQL ON CONFLICT syntax error

### DIFF
--- a/fix-signup-database-error.sql
+++ b/fix-signup-database-error.sql
@@ -180,8 +180,7 @@ SELECT
 FROM auth.users u
 LEFT JOIN public.profiles p ON p.id = u.id OR p.user_id = u.id
 WHERE p.id IS NULL
-ON CONFLICT (id) DO NOTHING
-ON CONFLICT (user_id) DO NOTHING;
+ON CONFLICT (id) DO NOTHING;
 
 -- Step 12: Final verification
 DO $$


### PR DESCRIPTION
Remove duplicate `ON CONFLICT` clause to fix SQL syntax error.

---
<a href="https://cursor.com/background-agent?bcId=bc-8efc0365-7b26-4a6f-bd5a-8078b66efaf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8efc0365-7b26-4a6f-bd5a-8078b66efaf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

