### PR TITLE
Fix sql on conflict syntax error

### DIFF
--- a/fix-signup-database-error.sql
+++ b/fix-signup-database-error.sql
@@ -103,12 +103,6 @@ BEGIN
         full_name = COALESCE(EXCLUDED.full_name, profiles.full_name),
         company_name = COALESCE(EXCLUDED.company_name, profiles.company_name),
         email_confirmed = EXCLUDED.email_confirmed,
-        updated_at = NOW()
-    ON CONFLICT (user_id) DO UPDATE SET
-        email = EXCLUDED.email,
-        full_name = COALESCE(EXCLUDED.full_name, profiles.full_name),
-        company_name = COALESCE(EXCLUDED.company_name, profiles.company_name),
-        email_confirmed = EXCLUDED.email_confirmed,
         updated_at = NOW();
 
     RETURN NEW;


### PR DESCRIPTION
Remove duplicate `ON CONFLICT (user_id)` clause to fix PostgreSQL syntax error.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd0c51d8-e9a8-4f43-be1f-458c297b806a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd0c51d8-e9a8-4f43-be1f-458c297b806a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

