### PR TITLE
Fix feedback widget send error

### DIFF
--- a/supabase/functions/submit-feedback/index.ts
+++ b/supabase/functions/submit-feedback/index.ts
@@ -56,29 +56,29 @@ serve(async (req) => {
       )
     }
 
-    // Check if project exists in projects table
-    const { data: project, error: projectError } = await supabase
-      .from('projects')
-      .select('id, user_id, project_id')
+    // Check if project exists in feedback_settings table by project_id
+    const { data: projectSettings, error: projectError } = await supabase
+      .from('feedback_settings')
+      .select('project_id')
       .eq('project_id', project_id)
-      .single()
+      .maybeSingle()
 
-    if (projectError || !project) {
-      console.error('Project not found:', project_id)
+    if (projectError || !projectSettings) {
+      console.error('Project not found in feedback_settings:', project_id, projectError)
       return new Response(
         JSON.stringify({ error: 'Project not found' }),
         { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       )
     }
 
-    // Insert feedback into feedbacks table
+    // Insert feedback into feedbacks table (schema: project_id TEXT, email TEXT, message TEXT, timestamp ...)
     const { data: feedback, error: feedbackError } = await supabase
       .from('feedbacks')
       .insert({
-        project_id: project.id, // Use the UUID from projects table
-        content: message.trim(),
-        user_email: email || null,
-        created_at: new Date().toISOString()
+        project_id: project_id,
+        email: email || null,
+        message: message.trim(),
+        timestamp: new Date().toISOString(),
       })
       .select('id')
       .single()


### PR DESCRIPTION
Update `submit-feedback` edge function to correctly validate projects against `feedback_settings` and insert feedback into `feedbacks` using the correct schema, resolving the "Failed to send feedback" error.

The previous implementation attempted to validate projects against a non-existent `projects` table and used incorrect column names (`content`, `user_email`, `created_at`) when inserting into the `feedbacks` table, causing submission failures. This change aligns the function with the expected `feedback_settings` table for project validation and the `feedbacks` table's actual schema (`project_id`, `email`, `message`, `timestamp`).

---
<a href="https://cursor.com/background-agent?bcId=bc-83cbcd7f-4e33-4a57-b914-fbe12b866710">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-83cbcd7f-4e33-4a57-b914-fbe12b866710">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

