### PR TITLE
Fix feedback submission error

### DIFF
--- a/supabase/functions/submit-feedback/index.ts
+++ b/supabase/functions/submit-feedback/index.ts
@@ -84,9 +84,28 @@ serve(async (req) => {
       .single()
 
     if (feedbackError) {
-      console.error('Error inserting feedback:', feedbackError)
+      // Improve diagnostics and map common DB errors to clearer HTTP responses
+      const errorMessage = typeof feedbackError === 'object' && feedbackError !== null ? (feedbackError as any).message || String(feedbackError) : String(feedbackError)
+      const errorCode = (feedbackError as any)?.code
+      const errorDetails = (feedbackError as any)?.details || (feedbackError as any)?.hint
+
+      console.error('Error inserting feedback:', { errorCode, errorMessage, errorDetails })
+
+      // 23503 = foreign_key_violation (e.g., invalid project_id referencing another table)
+      // 22P02 = invalid_text_representation (e.g., UUID expected)
+      // 23502 = not_null_violation
+      const isForeignKeyViolation = errorCode === '23503' || /foreign key/i.test(errorMessage)
+      const isInvalidUuid = errorCode === '22P02' || /uuid/i.test(errorMessage)
+
+      if (isForeignKeyViolation || isInvalidUuid) {
+        return new Response(
+          JSON.stringify({ error: 'Invalid project_id' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+
       return new Response(
-        JSON.stringify({ error: 'Failed to submit feedback' }),
+        JSON.stringify({ error: 'Failed to submit feedback', code: errorCode }),
         { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       )
     }


### PR DESCRIPTION
Improve feedback submission error handling to return specific 400 status for invalid `project_id`.

Previously, issues like an invalid `project_id` would result in a generic 500 error. This change provides clearer diagnostics and a more appropriate 400 status for such client-side input errors, making debugging easier.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a1332d9-df4b-4d48-8501-58ef584ceec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a1332d9-df4b-4d48-8501-58ef584ceec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

