### PR TITLE
Fix widget page sidebar 404 error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ const Dashboard = lazy(() => import("./pages/Dashboard"));
 const Insights = lazy(() => import("./pages/Insights"));
 const Feedback = lazy(() => import("./pages/Feedback"));
 const FeedbackSettings = lazy(() => import("./pages/FeedbackSettings"));
+const Widget = lazy(() => import("./pages/widget"));
 const Reports = lazy(() => import("./pages/Reports"));
 const Analytics = lazy(() => import("./pages/Analytics"));
 const Settings = lazy(() => import("./pages/Settings"));
@@ -216,6 +217,16 @@ const App = () => (
                 <Suspense fallback={<LoadingSpinner />}>
                   <DashboardLayout>
                     <FeedbackSettings />
+                  </DashboardLayout>
+                </Suspense>
+              </AuthGuard>
+            } />
+
+            <Route path="/widget" element={
+              <AuthGuard requireEmailConfirmation={true} requireActiveSubscription={false}>
+                <Suspense fallback={<LoadingSpinner />}>
+                  <DashboardLayout>
+                    <Widget />
                   </DashboardLayout>
                 </Suspense>
               </AuthGuard>

--- a/src/components/SidebarNavigation.tsx
+++ b/src/components/SidebarNavigation.tsx
@@ -37,6 +37,13 @@ const navigationItems: NavItem[] = [
     requiresAccess: true
   },
   {
+    id: 'widget',
+    label: 'Widget',
+    icon: <MessageSquare className="h-5 w-5" />,
+    path: '/widget',
+    requiresAccess: true
+  },
+  {
     id: 'feedback',
     label: 'Feedback',
     icon: <MessageSquare className="h-5 w-5" />,


### PR DESCRIPTION
Add a Widget page route and sidebar link to resolve the missing page and 404 error.

---
<a href="https://cursor.com/background-agent?bcId=bc-31dc5ea2-b689-451a-91a2-f62f44b33490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-31dc5ea2-b689-451a-91a2-f62f44b33490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

