### PR TITLE
Add light/dark mode toggle to top navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,22 @@
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
 
-    
+    <script>
+      (function() {
+        try {
+          var stored = localStorage.getItem('theme');
+          var mql = window.matchMedia('(prefers-color-scheme: dark)');
+          var shouldDark = stored ? stored === 'dark' : mql.matches;
+          if (shouldDark) {
+            document.documentElement.classList.add('dark');
+          } else {
+            document.documentElement.classList.remove('dark');
+          }
+        } catch (e) {
+          // no-op
+        }
+      })();
+    </script>
     <!-- NoteX Feedback Widget - Disabled to prevent console errors -->
     <script src="https://notex.com.ng/widget.js" data-project-id="32ffd49b"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import AuthGuard from "@/components/AuthGuard";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { lazy, Suspense } from "react";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 
 // Loading component
 const LoadingSpinner = () => (
@@ -71,6 +72,7 @@ const App = () => (
       <BrowserRouter>
         <AuthProvider>
           <UnifiedTrialProvider>
+            <ThemeProvider>
             <Routes>
             {/* Public routes */}
             <Route path="/" element={
@@ -308,7 +310,8 @@ const App = () => (
                 <NotFound />
               </Suspense>
             } />
-          </Routes>
+            </Routes>
+            </ThemeProvider>
           </UnifiedTrialProvider>
         </AuthProvider>
       </BrowserRouter>

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -169,47 +169,47 @@ const navigation = [
 
       {/* Sidebar */}
       <div className={cn(
-        "fixed inset-y-0 left-0 z-50 bg-gradient-to-b from-slate-50 to-white border-r border-slate-200 transform transition-all duration-300 ease-in-out lg:translate-x-0 shadow-xl max-h-screen",
+        "fixed inset-y-0 left-0 z-50 bg-gradient-to-b from-slate-50 to-white dark:from-slate-900 dark:to-slate-950 border-r border-slate-200 dark:border-slate-800 transform transition-all duration-300 ease-in-out lg:translate-x-0 shadow-xl max-h-screen",
         sidebarCollapsed ? "w-16" : "w-72",
         sidebarOpen ? "translate-x-0" : "-translate-x-full"
       )}>
         <div className="flex flex-col h-full">
           {/* Logo */}
-          <div className="flex items-center justify-between p-4 border-b border-slate-200 bg-white/50 backdrop-blur-sm">
+          <div className="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-800 bg-white/50 dark:bg-slate-900/50 backdrop-blur-sm transition-colors">
             <Link to="/dashboard" className="flex items-center space-x-3">
               <div className="w-10 h-10 bg-gradient-to-br rounded-xl flex items-center justify-center shadow-lg flex-shrink-0">
                 <img src="/favicon.ico" alt="NoteX" className="h-6 w-6" />
               </div>
               {!sidebarCollapsed && (
                 <div className="transition-opacity duration-300">
-                               <h1 className="text-lg font-bold text-slate-900">NoteX</h1>
-             <p className="text-xs text-slate-500">Turn feedback into growth ✨</p>
+                  <h1 className="text-lg font-bold text-slate-900 dark:text-slate-100">NoteX</h1>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">Turn feedback into growth ✨</p>
                 </div>
               )}
             </Link>
             <div className="flex items-center space-x-2">
               <button 
-                className="hidden lg:flex p-2 hover:bg-slate-100 rounded-lg transition-colors"
+                className="hidden lg:flex p-2 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-lg transition-colors"
                 onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
               >
                 {sidebarCollapsed ? (
-                  <ChevronRight className="h-4 w-4 text-slate-600" />
+                  <ChevronRight className="h-4 w-4 text-slate-600 dark:text-slate-300" />
                 ) : (
-                  <ChevronLeft className="h-4 w-4 text-slate-600" />
+                  <ChevronLeft className="h-4 w-4 text-slate-600 dark:text-slate-300" />
                 )}
               </button>
               <button 
-                className="lg:hidden p-2 hover:bg-slate-100 rounded-lg transition-colors"
+                className="lg:hidden p-2 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-lg transition-colors"
                 onClick={() => setSidebarOpen(false)}
               >
-                <X className="h-5 w-5 text-slate-600" />
+                <X className="h-5 w-5 text-slate-600 dark:text-slate-300" />
               </button>
             </div>
           </div>
 
           {/* User Profile Section */}
           {!loading && user && !sidebarCollapsed && (
-            <div className="p-6 border-b border-slate-200 bg-gradient-to-r from-blue-50 to-indigo-50">
+            <div className="p-6 border-b border-slate-200 dark:border-slate-800 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-slate-900 dark:to-slate-950">
               <div className="flex items-center space-x-3 mb-4">
                 <Avatar className="h-12 w-12 border-2 border-white shadow-lg">
                   <AvatarImage src={profile?.avatar_url} />
@@ -218,13 +218,13 @@ const navigation = [
                   </AvatarFallback>
                 </Avatar>
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-sm font-semibold text-slate-900 truncate">
+                  <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">
                     {profile?.first_name && profile?.last_name 
                       ? `${profile.first_name} ${profile.last_name}`
                       : user.email?.split('@')[0] || 'User'
                     }
                   </h3>
-                  <p className="text-xs text-slate-500 truncate">{user.email}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400 truncate">{user.email}</p>
                 </div>
               </div>
               
@@ -251,7 +251,7 @@ const navigation = [
 
           {/* Collapsed User Avatar */}
           {!loading && user && sidebarCollapsed && (
-            <div className="p-4 border-b border-slate-200 bg-gradient-to-r from-blue-50 to-indigo-50">
+            <div className="p-4 border-b border-slate-200 dark:border-slate-800 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-slate-900 dark:to-slate-950">
               <Avatar className="h-10 w-10 border-2 border-white shadow-lg mx-auto">
                 <AvatarImage src={profile?.avatar_url} />
                 <AvatarFallback className="bg-gradient-to-br from-blue-500 to-blue-600 text-white font-semibold text-sm">
@@ -294,7 +294,7 @@ const navigation = [
                         sidebarCollapsed ? "px-2 py-2 justify-center" : "px-3 py-2.5",
                         isActive
                           ? "bg-gradient-to-r from-blue-600 to-blue-700 text-white shadow-lg shadow-blue-500/25"
-                          : "text-slate-600 hover:text-slate-900 hover:bg-slate-100/80"
+                          : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100/80 dark:hover:bg-slate-800/60"
                       )}
                       onClick={() => setSidebarOpen(false)}
                       title={sidebarCollapsed ? item.name : undefined}
@@ -303,11 +303,11 @@ const navigation = [
                         "p-1 rounded-lg transition-colors relative",
                         isActive 
                           ? "bg-white/20" 
-                          : "bg-slate-100 group-hover:bg-slate-200"
+                          : "bg-slate-100 dark:bg-slate-800 group-hover:bg-slate-200 dark:group-hover:bg-slate-700"
                       )}>
                         <item.icon className={cn(
                           "h-4 w-4",
-                          isActive ? "text-white" : "text-slate-600"
+                          isActive ? "text-white" : "text-slate-600 dark:text-slate-300"
                         )} />
                         {item.notificationCount && item.notificationCount > 0 && (
                           <Badge 
@@ -344,7 +344,7 @@ const navigation = [
           </nav>
 
           {/* User Menu */}
-          <div className="p-3 border-t border-slate-200 bg-white/50 backdrop-blur-sm">
+          <div className="p-3 border-t border-slate-200 dark:border-slate-800 bg-white/50 dark:bg-slate-900/50 backdrop-blur-sm transition-colors">
             <div className="space-y-1">
              
               
@@ -356,7 +356,7 @@ const navigation = [
                 )}
                 title={sidebarCollapsed ? "Sign Out" : undefined}
               >
-                <div className="p-1 rounded-lg bg-red-100 group-hover:bg-red-200 transition-colors">
+                <div className="p-1 rounded-lg bg-red-100 dark:bg-red-900/30 group-hover:bg-red-200 dark:group-hover:bg-red-900/40 transition-colors">
                   <LogOut className="h-4 w-4 text-red-600" />
                 </div>
                 {!sidebarCollapsed && <span className="flex-1">Sign Out</span>}

--- a/src/components/layout/TopNav.tsx
+++ b/src/components/layout/TopNav.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { useTheme } from "@/contexts/ThemeContext";
+import { Moon, Sun } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/integrations/supabase/client";
 
@@ -23,6 +25,7 @@ export default function TopNav({ className }: TopNavProps) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
+  const { theme, toggleTheme } = useTheme();
 
   useEffect(() => {
     const load = async () => {
@@ -74,7 +77,7 @@ export default function TopNav({ className }: TopNavProps) {
   };
 
   return (
-    <div className={cn("sticky top-0 z-40 w-full bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b border-slate-200", className)}>
+    <div className={cn("sticky top-0 z-40 w-full bg-white/80 dark:bg-slate-900/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:supports-[backdrop-filter]:bg-slate-900/60 border-b border-slate-200 dark:border-slate-800 transition-colors", className)}>
       <div className="h-14 md:h-16 px-3 md:px-6 flex items-center justify-between">
         {/* Left: Logo / Brand */}
         <Link to={user ? "/dashboard" : "/"} className="flex items-center gap-2 min-w-0">
@@ -82,11 +85,26 @@ export default function TopNav({ className }: TopNavProps) {
           <span className="font-semibold text-sm md:text-base truncate">NoteX</span>
         </Link>
 
-        {/* Right: Avatar */}
-        <div className="relative" ref={dropdownRef}>
+        {/* Right: Theme toggle + Avatar */}
+        <div className="flex items-center gap-1 md:gap-2">
           <Button
             variant="ghost"
-            className="h-9 w-9 md:h-10 md:w-10 p-0 rounded-full hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-blue-500"
+            size="icon"
+            className="h-9 w-9 md:h-10 md:w-10 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+            onClick={toggleTheme}
+            aria-label="Toggle theme"
+          >
+            {theme === "dark" ? (
+              <Sun className="h-5 w-5 text-foreground" />
+            ) : (
+              <Moon className="h-5 w-5 text-foreground" />
+            )}
+          </Button>
+
+          <div className="relative" ref={dropdownRef}>
+          <Button
+            variant="ghost"
+            className="h-9 w-9 md:h-10 md:w-10 p-0 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 focus-visible:ring-2 focus-visible:ring-blue-500"
             onClick={() => setIsOpen((v) => !v)}
             aria-haspopup="menu"
             aria-expanded={isOpen}
@@ -101,7 +119,7 @@ export default function TopNav({ className }: TopNavProps) {
           {/* Dropdown */}
           <div
             className={cn(
-              "absolute right-0 mt-2 w-48 md:w-56 origin-top-right rounded-lg border border-slate-200 bg-white shadow-lg ring-1 ring-black/5 transition ease-out duration-150",
+              "absolute right-0 mt-2 w-48 md:w-56 origin-top-right rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-lg ring-1 ring-black/5 dark:ring-white/5 transition ease-out duration-150",
               isOpen ? "opacity-100 scale-100" : "opacity-0 scale-95 pointer-events-none"
             )}
             role="menu"
@@ -109,7 +127,7 @@ export default function TopNav({ className }: TopNavProps) {
             <div className="py-1">
               <Link
                 to="/profile"
-                className="block px-3 py-2 text-sm text-slate-700 hover:bg-slate-50"
+                className="block px-3 py-2 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800"
                 role="menuitem"
                 onClick={() => setIsOpen(false)}
               >
@@ -117,20 +135,21 @@ export default function TopNav({ className }: TopNavProps) {
               </Link>
               <Link
                 to="/settings"
-                className="block px-3 py-2 text-sm text-slate-700 hover:bg-slate-50"
+                className="block px-3 py-2 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800"
                 role="menuitem"
                 onClick={() => setIsOpen(false)}
               >
                 Settings
               </Link>
               <button
-                className="w-full text-left block px-3 py-2 text-sm text-red-600 hover:bg-red-50"
+                className="w-full text-left block px-3 py-2 text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
                 role="menuitem"
                 onClick={handleSignOut}
               >
                 Sign Out
               </button>
             </div>
+          </div>
           </div>
         </div>
       </div>

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,68 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const useTheme = (): ThemeContextValue => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+};
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const getInitialTheme = (): Theme => {
+    if (typeof window === "undefined") return "light";
+    try {
+      const stored = localStorage.getItem("theme") as Theme | null;
+      if (stored === "light" || stored === "dark") return stored;
+      return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    } catch {
+      return "light";
+    }
+  };
+
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    try {
+      localStorage.setItem("theme", theme);
+    } catch {}
+  }, [theme]);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => {
+      const stored = localStorage.getItem("theme");
+      if (!stored) {
+        setThemeState(mql.matches ? "dark" : "light");
+      }
+    };
+    mql.addEventListener?.("change", onChange);
+    return () => mql.removeEventListener?.("change", onChange);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme: (t: Theme) => setThemeState(t),
+      toggleTheme: () => setThemeState((t) => (t === "dark" ? "light" : "dark")),
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+

--- a/src/index.css
+++ b/src/index.css
@@ -120,7 +120,7 @@
   }
 
   body {
-    @apply bg-background text-foreground font-sans antialiased;
+    @apply bg-background text-foreground font-sans antialiased transition-colors duration-300;
     font-family: 'Inter', system-ui, -apple-system, sans-serif;
   }
   


### PR DESCRIPTION
Implement a persistent day/night (light/dark) mode toggle in the dashboard top navigation bar to allow users to switch themes globally.

---
<a href="https://cursor.com/background-agent?bcId=bc-eceb9bc9-d633-4e23-9aba-6bb5d6d18a72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eceb9bc9-d633-4e23-9aba-6bb5d6d18a72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

