### PR TITLE
Implement 30-day rolling free plan limits

### DIFF
--- a/src/components/billing/PlanComparison.tsx
+++ b/src/components/billing/PlanComparison.tsx
@@ -102,7 +102,7 @@ const PlanComparison: React.FC<PlanComparisonProps> = ({
           <h2 className="text-3xl font-bold text-gray-900">Choose Your Plan</h2>
         </div>
         <p className="text-gray-600 text-lg max-w-2xl mx-auto">
-          Start with a free trial, then upgrade to Business for unlimited access to all features
+          Free plan has a 30-day rolling period with limits: 50 Feedback, 5 Insights, 5 Reports. Upgrade to Business for unlimited features.
         </p>
       </div>
 

--- a/src/components/billing/UsageDashboard.tsx
+++ b/src/components/billing/UsageDashboard.tsx
@@ -129,44 +129,33 @@ const UsageDashboard: React.FC<UsageDashboardProps> = ({
           </div>
         </CardHeader>
         <CardContent>
-          {/* Trial Status */}
+          {/* Free Plan 30-day Cycle Status */}
           {plan === 'free' && (
             <div className={`p-4 rounded-lg mb-4 ${
-              isTrialExpired 
-                ? 'bg-red-50 border border-red-200' 
-                : daysUntilExpiry <= 3 
-                  ? 'bg-yellow-50 border border-yellow-200'
-                  : 'bg-blue-50 border border-blue-200'
+              daysUntilExpiry <= 3 
+                ? 'bg-yellow-50 border border-yellow-200' 
+                : 'bg-blue-50 border border-blue-200'
             }`}>
               <div className="flex items-center gap-2 mb-2">
                 <Clock className={`h-4 w-4 ${
-                  isTrialExpired 
-                    ? 'text-red-600' 
-                    : daysUntilExpiry <= 3 
-                      ? 'text-yellow-600'
-                      : 'text-blue-600'
+                  daysUntilExpiry <= 3 
+                    ? 'text-yellow-600' 
+                    : 'text-blue-600'
                 }`} />
                 <span className={`font-medium ${
-                  isTrialExpired 
-                    ? 'text-red-800' 
-                    : daysUntilExpiry <= 3 
-                      ? 'text-yellow-800'
-                      : 'text-blue-800'
+                  daysUntilExpiry <= 3 
+                    ? 'text-yellow-800' 
+                    : 'text-blue-800'
                 }`}>
-                  {isTrialExpired ? 'Trial Expired' : 'Free Trial Active'}
+                  Free Plan: 30-day rolling usage
                 </span>
               </div>
               <p className={`text-sm ${
-                isTrialExpired 
-                  ? 'text-red-700' 
-                  : daysUntilExpiry <= 3 
-                    ? 'text-yellow-700'
-                    : 'text-blue-700'
+                daysUntilExpiry <= 3 
+                  ? 'text-yellow-700' 
+                  : 'text-blue-700'
               }`}>
-                {isTrialExpired 
-                  ? 'Your free trial has ended. Upgrade to continue using NoteX.'
-                  : `Your trial ends in ${daysUntilExpiry} day${daysUntilExpiry !== 1 ? 's' : ''}. Upgrade now to avoid losing access.`
-                }
+                Cycle resets in {daysUntilExpiry} day{daysUntilExpiry !== 1 ? 's' : ''}. Limits per cycle: Feedback 50, Insights 5, Reports 5. Data retention: 8 days.
               </p>
             </div>
           )}

--- a/src/components/billing/UsageOverview.tsx
+++ b/src/components/billing/UsageOverview.tsx
@@ -242,6 +242,7 @@ export default function UsageOverview({ userId, onUpgrade, refreshTrigger }: Usa
       <div className="flex items-center justify-between mb-6">
         <div>
           <h2 className="text-2xl font-bold text-gray-900">Usage Overview</h2>
+          <p className="text-sm text-gray-600 mt-1">Free plan resets every 30 days (rolling). Limits per cycle: Feedback 50, Insights 5, Reports 5. Data retention: 8 days.</p>
           <div className="mt-2 space-y-1">
             <div className="flex items-center gap-2">
               <p className="text-gray-600">Current Plan:</p>

--- a/src/hooks/useBillingEnforcement.ts
+++ b/src/hooks/useBillingEnforcement.ts
@@ -81,8 +81,8 @@ export function useBillingEnforcement(): UseBillingEnforcementReturn {
   const [limits, setLimits] = useState<UsageLimits>({
     feedback: 50,
     insights: 5,
-    reports: 2,
-    retention_days: 30
+    reports: 5,
+    retention_days: 8
   });
   const [checks, setChecks] = useState<Record<FeatureType, UsageCheckResult>>({
     feedback: {
@@ -204,8 +204,8 @@ export function useBillingEnforcement(): UseBillingEnforcementReturn {
   // Computed values
   const needsUpgradeCheck = needsUpgrade(checks);
   const featuresNeedingUpgrade = getFeaturesNeedingUpgrade(checks);
-  const hasActiveAccess = subscription?.status === 'active' || (!isTrialExpired && subscription?.status === 'trialing');
-  const isTrialActive = subscription?.status === 'trialing' && !isTrialExpired;
+  const hasActiveAccess = true; // Free plan stays active with rolling cycles
+  const isTrialActive = false;
 
   // Load data on mount and when user changes
   useEffect(() => {

--- a/src/hooks/useBillingSystem.ts
+++ b/src/hooks/useBillingSystem.ts
@@ -87,8 +87,8 @@ export interface BillingSystemState {
 const PLAN_LIMITS: Record<string, UsageLimits> = {
   trial: {
     feedback: 50,
-    analytics: 5,
-    reports: 2,
+    analytics: 0,
+    reports: 5,
     insights: 5,
     teams: 1,
     export: ['CSV'],

--- a/src/lib/billingEnforcement.ts
+++ b/src/lib/billingEnforcement.ts
@@ -64,8 +64,8 @@ export const PLAN_LIMITS: Record<PlanTier, UsageLimits> = {
   free: {
     feedback: 50,
     insights: 5,
-    reports: 2,
-    retention_days: 30
+    reports: 5,
+    retention_days: 8
   },
   pro: {
     feedback: 300,
@@ -83,7 +83,7 @@ export const PLAN_LIMITS: Record<PlanTier, UsageLimits> = {
 
 // Plan display names
 export const PLAN_NAMES: Record<PlanTier, string> = {
-  free: 'Free Trial',
+  free: 'Free Plan',
   pro: 'Pro Plan',
   business: 'Business Plan'
 };
@@ -142,29 +142,29 @@ export async function getUserSubscription(userId: string): Promise<SubscriptionD
  */
 export async function getUserUsage(userId: string): Promise<UsageData | null> {
   try {
-    // Use usage_tracking table with type assertion
+    // Use rolling 30-day cycle from usage_counters via RPC
     const { data, error } = await (supabase as any)
-      .from('usage_tracking')
-      .select('*')
-      .eq('user_id', userId)
-      .single();
+      .rpc('ensure_current_cycle_usage', { user_uuid: userId });
 
     if (error && error.code !== 'PGRST116') {
       console.error('Error fetching usage data:', error);
       return null;
     }
 
-    // Map usage_tracking data to UsageData interface
-    if (data) {
+    // ensure_current_cycle_usage returns a row or array; normalize
+    const row = Array.isArray(data) ? data[0] : data;
+    if (row) {
+      const cycleStart = row.cycle_start || row.period_start || row.month_start;
+      const updatedAt = row.updated_at || new Date().toISOString();
       return {
-        user_id: data.user_id,
-        period_start: data.created_at,
-        period_end: new Date(new Date(data.created_at).getTime() + 30 * 24 * 60 * 60 * 1000).toISOString(),
-        feedback_count: data.feedback_count || 0,
-        insights_count: data.insights_count || 0,
-        reports_count: data.reports_count || 0,
-        last_reset: data.updated_at,
-        updated_at: data.updated_at,
+        user_id: row.user_id,
+        period_start: cycleStart,
+        period_end: new Date(new Date(cycleStart).getTime() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+        feedback_count: row.feedback_count || 0,
+        insights_count: row.insights_count || 0,
+        reports_count: row.reports_count || 0,
+        last_reset: updatedAt,
+        updated_at: updatedAt,
       } as UsageData;
     }
 
@@ -184,17 +184,19 @@ export function checkUsageLimit(
   plan: PlanTier,
   isTrialExpired: boolean = false
 ): UsageCheckResult {
-  // UNLOCKED PLATFORM: Always allow usage
-  console.log('🔓 UNLOCKED PLATFORM - Usage limit check always allows usage');
+  const limit = PLAN_LIMITS[plan][feature];
+  const isUnlimited = limit === -1;
+  const canUse = isUnlimited || currentUsage < limit;
+  const remaining = isUnlimited ? -1 : Math.max(0, limit - currentUsage);
   return {
-    canUse: true,
+    canUse,
     currentUsage,
-    limit: -1, // Unlimited
+    limit,
     plan,
     feature,
-    isUnlimited: true,
-    remaining: -1,
-    isTrialExpired: false,
+    isUnlimited,
+    remaining,
+    isTrialExpired,
     daysUntilExpiry: 0
   };
 }
@@ -203,8 +205,7 @@ export function checkUsageLimit(
  * Check if user's trial has expired
  */
 export function isTrialExpired(subscription: SubscriptionData | null): boolean {
-  // UNLOCKED PLATFORM: Trial never expires
-  console.log('🔓 UNLOCKED PLATFORM - Trial never expires');
+  // Free plan rolls every 30 days; no expiration concept
   return false;
 }
 
@@ -212,9 +213,8 @@ export function isTrialExpired(subscription: SubscriptionData | null): boolean {
  * Get days until trial/subscription expires
  */
 export function getDaysUntilExpiry(subscription: SubscriptionData | null): number {
-  // UNLOCKED PLATFORM: Never expires
-  console.log('🔓 UNLOCKED PLATFORM - Never expires');
-  return 999; // Return a large number to indicate unlimited
+  // Handled in getUsageSummary using the rolling cycle window
+  return 0;
 }
 
 /**
@@ -238,7 +238,13 @@ export async function checkFeatureUsage(
     const plan = subscription.plan_tier;
     const currentUsage = usage[`${feature}_count` as keyof UsageData] as number;
     const trialExpired = isTrialExpired(subscription);
-    const daysUntilExpiry = getDaysUntilExpiry(subscription);
+    // Compute days until cycle reset
+    let daysUntilExpiry = 0;
+    if (usage?.period_end) {
+      const end = new Date(usage.period_end);
+      const now = new Date();
+      daysUntilExpiry = Math.max(0, Math.ceil((end.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)));
+    }
 
     const result = checkUsageLimit(feature, currentUsage, plan, trialExpired);
     

--- a/supabase/migrations/20250915000000_free_plan_rolling_cycle.sql
+++ b/supabase/migrations/20250915000000_free_plan_rolling_cycle.sql
@@ -1,0 +1,341 @@
+-- NoteX: 30-day rolling free plan implementation
+-- - Adds cycle_start to usage_counters for per-user rolling windows
+-- - Reworks ensure/get/increment/enforcement to use 30-day cycle
+-- - Updates free plan limits per requirements
+
+-- 1) Schema updates: usage_counters add cycle_start and index/uniq
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' AND table_name = 'usage_counters' AND column_name = 'cycle_start'
+  ) THEN
+    ALTER TABLE usage_counters ADD COLUMN cycle_start DATE;
+  END IF;
+END $$;
+
+-- Backfill cycle_start from month_start if present; else default to today
+UPDATE usage_counters 
+SET cycle_start = COALESCE(cycle_start, month_start, CURRENT_DATE)
+WHERE cycle_start IS NULL;
+
+-- Unique constraint on (user_id, cycle_start)
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints 
+    WHERE table_schema = 'public' 
+      AND table_name = 'usage_counters' 
+      AND constraint_name = 'usage_counters_user_cycle_unique'
+  ) THEN
+    ALTER TABLE usage_counters
+    ADD CONSTRAINT usage_counters_user_cycle_unique UNIQUE (user_id, cycle_start);
+  END IF;
+END $$;
+
+-- Helpful indexes
+CREATE INDEX IF NOT EXISTS idx_usage_counters_user_cycle ON usage_counters(user_id, cycle_start);
+
+-- 2) Helper: get current rolling cycle start for a user (30-day window)
+CREATE OR REPLACE FUNCTION get_current_cycle_start(user_uuid UUID)
+RETURNS DATE
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_cycle_start DATE;
+BEGIN
+  SELECT uc.cycle_start
+  INTO v_cycle_start
+  FROM usage_counters uc
+  WHERE uc.user_id = user_uuid
+  ORDER BY uc.cycle_start DESC
+  LIMIT 1;
+
+  IF v_cycle_start IS NULL THEN
+    RETURN CURRENT_DATE; -- first use starts today
+  END IF;
+
+  IF CURRENT_DATE >= (v_cycle_start + INTERVAL '30 days') THEN
+    RETURN CURRENT_DATE; -- start a new 30-day cycle
+  END IF;
+
+  RETURN v_cycle_start; -- still within current cycle
+END;
+$$;
+
+-- 3) Ensure there is a usage row for the current rolling cycle
+CREATE OR REPLACE FUNCTION ensure_current_cycle_usage(user_uuid UUID)
+RETURNS TABLE (
+  user_id UUID,
+  cycle_start DATE,
+  feedback_count INTEGER,
+  insights_count INTEGER,
+  analytics_count INTEGER,
+  reports_count INTEGER,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_cycle_start DATE := get_current_cycle_start(user_uuid);
+  rec RECORD;
+BEGIN
+  -- If past cycle expired, start a new one with zeroed counters
+  SELECT * INTO rec
+  FROM usage_counters
+  WHERE user_id = user_uuid AND cycle_start = v_cycle_start
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    INSERT INTO usage_counters (
+      user_id, cycle_start, month_start, feedback_count, insights_count, analytics_count, reports_count, created_at, updated_at
+    ) VALUES (
+      user_uuid, v_cycle_start, DATE_TRUNC('month', v_cycle_start)::DATE, 0, 0, 0, 0, NOW(), NOW()
+    )
+    ON CONFLICT (user_id, cycle_start) DO NOTHING;
+  END IF;
+
+  RETURN QUERY
+  SELECT uc.user_id, uc.cycle_start, COALESCE(uc.feedback_count, 0), COALESCE(uc.insights_count, 0), COALESCE(uc.analytics_count, 0), COALESCE(uc.reports_count, 0), uc.created_at, uc.updated_at
+  FROM usage_counters uc
+  WHERE uc.user_id = user_uuid AND uc.cycle_start = v_cycle_start
+  LIMIT 1;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION ensure_current_cycle_usage(UUID) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION get_current_cycle_start(UUID) TO authenticated, service_role;
+
+-- 4) Update get_plan_limits to reflect new free plan limits
+--    Free: Feedback 50, AI Insights 5, Reports 5. Others unchanged.
+CREATE OR REPLACE FUNCTION get_plan_limits(plan_code TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    limits JSONB;
+BEGIN
+    CASE plan_code
+        WHEN 'free' THEN
+            limits := jsonb_build_object(
+              'feedback', 50,
+              'insights', 5,
+              'analytics', 0,
+              'reports', 5
+            );
+        WHEN 'pro' THEN  
+            limits := jsonb_build_object(
+              'feedback', 300,
+              'insights', 50,
+              'analytics', 50,
+              'reports', 20
+            );
+        WHEN 'business' THEN
+            limits := jsonb_build_object(
+              'feedback', -1,
+              'insights', -1,
+              'analytics', -1,
+              'reports', -1
+            );
+        ELSE
+            limits := jsonb_build_object(
+              'feedback', 50,
+              'insights', 5,
+              'analytics', 0,
+              'reports', 5
+            );
+    END CASE;
+    RETURN limits;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_plan_limits(TEXT) TO authenticated, service_role;
+
+-- 5) can_use_feature: now uses rolling cycle
+CREATE OR REPLACE FUNCTION can_use_feature(user_uuid UUID, feature_name TEXT)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_cycle_start DATE := get_current_cycle_start(user_uuid);
+  usage_record RECORD;
+  plan_limits JSONB;
+  limit_value INT;
+  current_usage INT;
+  user_plan_code TEXT;
+BEGIN
+  PERFORM ensure_current_cycle_usage(user_uuid);
+
+  SELECT uc.*, COALESCE(bp.plan, 'free') as plan_code
+  INTO usage_record
+  FROM usage_counters uc
+  LEFT JOIN billing_profiles bp ON bp.id = uc.user_id
+  WHERE uc.user_id = user_uuid AND uc.cycle_start = v_cycle_start
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN FALSE;
+  END IF;
+
+  plan_limits := get_plan_limits(usage_record.plan_code);
+
+  CASE feature_name
+    WHEN 'feedback' THEN
+      current_usage := COALESCE(usage_record.feedback_count, 0);
+      limit_value := (plan_limits->>'feedback')::INT;
+    WHEN 'insights' THEN
+      current_usage := COALESCE(usage_record.insights_count, 0);
+      limit_value := (plan_limits->>'insights')::INT;
+    WHEN 'analytics' THEN
+      current_usage := COALESCE(usage_record.analytics_count, 0);
+      limit_value := (plan_limits->>'analytics')::INT;
+    WHEN 'reports' THEN
+      current_usage := COALESCE(usage_record.reports_count, 0);
+      limit_value := (plan_limits->>'reports')::INT;
+    ELSE
+      RETURN FALSE;
+  END CASE;
+
+  IF limit_value = -1 THEN
+    RETURN TRUE;
+  END IF;
+
+  RETURN current_usage < limit_value;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION can_use_feature(UUID, TEXT) TO authenticated, service_role;
+
+-- 6) increment_usage_with_check: now uses rolling cycle and returns JSONB
+CREATE OR REPLACE FUNCTION increment_usage_with_check(user_uuid UUID, feature_name TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_cycle_start DATE := get_current_cycle_start(user_uuid);
+  can_use BOOLEAN;
+  result JSONB;
+BEGIN
+  -- Ensure current cycle exists and check
+  PERFORM ensure_current_cycle_usage(user_uuid);
+  can_use := can_use_feature(user_uuid, feature_name);
+  IF NOT can_use THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Usage limit exceeded for ' || feature_name, 'feature', feature_name);
+  END IF;
+
+  -- Increment appropriate counter
+  CASE feature_name
+    WHEN 'feedback' THEN
+      UPDATE usage_counters SET feedback_count = COALESCE(feedback_count,0) + 1, updated_at = NOW()
+      WHERE user_id = user_uuid AND cycle_start = v_cycle_start;
+    WHEN 'insights' THEN
+      UPDATE usage_counters SET insights_count = COALESCE(insights_count,0) + 1, updated_at = NOW()
+      WHERE user_id = user_uuid AND cycle_start = v_cycle_start;
+    WHEN 'analytics' THEN
+      UPDATE usage_counters SET analytics_count = COALESCE(analytics_count,0) + 1, updated_at = NOW()
+      WHERE user_id = user_uuid AND cycle_start = v_cycle_start;
+    WHEN 'reports' THEN
+      UPDATE usage_counters SET reports_count = COALESCE(reports_count,0) + 1, updated_at = NOW()
+      WHERE user_id = user_uuid AND cycle_start = v_cycle_start;
+  END CASE;
+
+  -- Return updated snapshot
+  SELECT jsonb_build_object(
+    'success', true,
+    'feature', feature_name,
+    'current_usage', CASE feature_name
+      WHEN 'feedback' THEN uc.feedback_count
+      WHEN 'insights' THEN uc.insights_count
+      WHEN 'analytics' THEN uc.analytics_count
+      WHEN 'reports' THEN uc.reports_count
+    END,
+    'plan', COALESCE(bp.plan, 'free'),
+    'cycle_start', uc.cycle_start,
+    'cycle_end', (uc.cycle_start + INTERVAL '30 days')::date
+  ) INTO result
+  FROM usage_counters uc
+  LEFT JOIN billing_profiles bp ON bp.id = uc.user_id
+  WHERE uc.user_id = user_uuid AND uc.cycle_start = v_cycle_start
+  LIMIT 1;
+
+  RETURN result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION increment_usage_with_check(UUID, TEXT) TO authenticated, service_role;
+
+-- 7) Optional: utility to compute days remaining in current cycle
+CREATE OR REPLACE FUNCTION get_cycle_days_remaining(user_uuid UUID)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_cycle_start DATE := get_current_cycle_start(user_uuid);
+  days_left INT;
+BEGIN
+  days_left := GREATEST(0, (v_cycle_start + INTERVAL '30 days')::date - CURRENT_DATE);
+  RETURN days_left;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_cycle_days_remaining(UUID) TO authenticated, service_role;
+
+-- 8) Notes:
+-- - Existing calendar-month functions remain for compatibility but are superseded by rolling-cycle versions above.
+-- - Frontend should display cycle window [cycle_start, cycle_start+30d) and updated free limits.
+-- - Data retention for free users (8 days) to be enforced at application layer or via separate cleanup job.
+
+-- 9) Optional notifications: get users nearing limits or cycle reset
+CREATE OR REPLACE FUNCTION get_users_near_free_limits(threshold_percent INT DEFAULT 90)
+RETURNS TABLE (
+  user_id UUID,
+  feature TEXT,
+  current_usage INT,
+  limit_value INT,
+  percentage INT,
+  cycle_days_remaining INT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  lims JSONB;
+  v_cycle_start DATE;
+  days_left INT;
+BEGIN
+  FOR user_id IN SELECT DISTINCT user_id FROM usage_counters LOOP
+    v_cycle_start := get_current_cycle_start(user_id);
+    days_left := GREATEST(0, (v_cycle_start + INTERVAL '30 days')::date - CURRENT_DATE);
+    SELECT get_plan_limits(COALESCE(bp.plan, 'free')) INTO lims
+    FROM billing_profiles bp WHERE bp.id = user_id;
+    IF lims IS NULL THEN lims := get_plan_limits('free'); END IF;
+
+    RETURN QUERY
+    WITH uc AS (
+      SELECT * FROM usage_counters WHERE user_id = get_users_near_free_limits.user_id AND cycle_start = v_cycle_start
+    )
+    SELECT get_users_near_free_limits.user_id, feat.feature, feat.current_usage, feat.limit_value,
+           CASE WHEN feat.limit_value = -1 THEN 0 ELSE (feat.current_usage * 100 / GREATEST(feat.limit_value,1)) END as percentage,
+           days_left
+    FROM (
+      SELECT 'feedback'::text as feature, COALESCE(u.feedback_count,0) as current_usage, (lims->>'feedback')::int as limit_value FROM uc u
+      UNION ALL
+      SELECT 'insights', COALESCE(u.insights_count,0), (lims->>'insights')::int FROM uc u
+      UNION ALL
+      SELECT 'analytics', COALESCE(u.analytics_count,0), (lims->>'analytics')::int FROM uc u
+      UNION ALL
+      SELECT 'reports', COALESCE(u.reports_count,0), (lims->>'reports')::int FROM uc u
+    ) feat
+    WHERE feat.limit_value <> -1
+      AND (feat.current_usage * 100 / GREATEST(feat.limit_value,1)) >= threshold_percent;
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_users_near_free_limits(INT) TO service_role;
+


### PR DESCRIPTION
Implement a 30-day rolling free plan with specific feature limits and automatic resets.

This PR redesigns the NoteX free user plan from a trial-based model to a 30-day rolling cycle with defined limits for feedback (50), AI insights (5), reports (5), and data retention (8 days), including backend enforcement and UI updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-d40984df-d3da-426e-9829-fc53493d9bde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d40984df-d3da-426e-9829-fc53493d9bde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

