### PR TITLE
Fix feedback page and settings schema

### DIFF
--- a/src/pages/Feedback.tsx
+++ b/src/pages/Feedback.tsx
@@ -57,10 +57,15 @@ import {
 interface Feedback {
   id: string;
   project_id: string;
-  email: string | null;
-  message: string;
-  page_url: string | null;
-  browser: string | null;
+  user_email: string | null;
+  content: string;
+  sentiment: string | null;
+  metadata: {
+    email?: string;
+    page_url?: string;
+    user_agent?: string;
+    [key: string]: any;
+  };
   created_at: string;
 }
 
@@ -125,14 +130,14 @@ export default function Feedback() {
 
       // Load feedbacks
       const { data: feedbacksData, error: feedbacksError } = await supabase
-        .from('feedback')
+        .from('feedbacks')
         .select(`
           id,
           project_id,
-          email,
-          message,
-          page_url,
-          browser,
+          user_email,
+          content,
+          sentiment,
+          metadata,
           created_at
         `)
         .in('project_id', projectIds)
@@ -149,15 +154,26 @@ export default function Feedback() {
       const feedbacksList = feedbacksData || [];
       const totalFeedback = feedbacksList.length;
       
-      // Since the current feedback table doesn't have rating/form_type, we'll use basic stats
-      const averageRating = 0; // Will be calculated when rating data is available
-      const customerSatisfactionCount = 0; // Will be calculated when form_type data is available
-      const productFeedbackCount = totalFeedback; // All feedback is product feedback for now
+      // Calculate sentiment-based stats since we don't have rating/form_type
+      const positiveCount = feedbacksList.filter(f => f.sentiment === 'positive').length;
+      const negativeCount = feedbacksList.filter(f => f.sentiment === 'negative').length;
+      const neutralCount = feedbacksList.filter(f => f.sentiment === 'neutral').length;
       
-      const ratingDistribution: { [key: number]: number } = {};
-      for (let i = 1; i <= 5; i++) {
-        ratingDistribution[i] = 0; // Will be populated when rating data is available
-      }
+      // Use sentiment as a proxy for rating (positive = 5, neutral = 3, negative = 1)
+      const averageRating = totalFeedback > 0 ? 
+        (positiveCount * 5 + neutralCount * 3 + negativeCount * 1) / totalFeedback : 0;
+      
+      // For now, treat all feedback as product feedback since we don't have form_type
+      const customerSatisfactionCount = 0;
+      const productFeedbackCount = totalFeedback;
+      
+      const ratingDistribution: { [key: number]: number } = {
+        1: negativeCount,
+        2: 0,
+        3: neutralCount,
+        4: 0,
+        5: positiveCount
+      };
 
       setStats({
         totalFeedback,
@@ -194,7 +210,7 @@ export default function Feedback() {
         {
           event: '*',
           schema: 'public',
-          table: 'feedback'
+          table: 'feedbacks'
         },
         (payload) => {
           console.log('Feedback change received:', payload);
@@ -241,8 +257,9 @@ export default function Feedback() {
     if (filters.searchQuery) {
       const query = filters.searchQuery.toLowerCase();
       filtered = filtered.filter(f => 
-        f.message.toLowerCase().includes(query) ||
-        (f.email && f.email.toLowerCase().includes(query))
+        f.content.toLowerCase().includes(query) ||
+        (f.user_email && f.user_email.toLowerCase().includes(query)) ||
+        (f.metadata?.email && f.metadata.email.toLowerCase().includes(query))
       );
     }
 
@@ -286,13 +303,14 @@ export default function Feedback() {
   // Export functionality
   const exportToCSV = () => {
     const csvContent = [
-      ['Date', 'Message', 'Email', 'Page URL', 'Browser'].join(','),
+      ['Date', 'Content', 'Email', 'Sentiment', 'Page URL', 'User Agent'].join(','),
       ...filteredFeedbacks.map(f => [
         new Date(f.created_at).toLocaleDateString(),
-        `"${f.message.replace(/"/g, '""')}"`,
-        f.email || '',
-        f.page_url || '',
-        f.browser || ''
+        `"${f.content.replace(/"/g, '""')}"`,
+        f.user_email || f.metadata?.email || '',
+        f.sentiment || '',
+        f.metadata?.page_url || '',
+        f.metadata?.user_agent || ''
       ].join(','))
     ].join('\n');
 
@@ -656,22 +674,27 @@ export default function Feedback() {
                       <Badge variant="secondary">
                         Product Feedback
                       </Badge>
+                      {feedback.sentiment && (
+                        <Badge variant={feedback.sentiment === 'positive' ? 'default' : feedback.sentiment === 'negative' ? 'destructive' : 'secondary'}>
+                          {feedback.sentiment}
+                        </Badge>
+                      )}
                     </div>
                     <div className="flex items-center space-x-2 text-sm text-gray-500">
                       <Clock className="h-4 w-4" />
                       <span>{format(new Date(feedback.created_at), 'MMM dd, yyyy HH:mm')}</span>
                     </div>
                   </div>
-                  <p className="text-gray-700 text-sm mb-2">{feedback.message}</p>
+                  <p className="text-gray-700 text-sm mb-2">{feedback.content}</p>
                   <div className="flex items-center space-x-4 text-xs text-gray-500">
-                    {feedback.email && (
-                      <span>From: {feedback.email}</span>
+                    {(feedback.user_email || feedback.metadata?.email) && (
+                      <span>From: {feedback.user_email || feedback.metadata?.email}</span>
                     )}
-                    {feedback.page_url && (
-                      <span>Page: {feedback.page_url}</span>
+                    {feedback.metadata?.page_url && (
+                      <span>Page: {feedback.metadata.page_url}</span>
                     )}
-                    {feedback.browser && (
-                      <span>Browser: {feedback.browser}</span>
+                    {feedback.metadata?.user_agent && (
+                      <span>Browser: {feedback.metadata.user_agent}</span>
                     )}
                   </div>
                 </div>

--- a/src/pages/FeedbackSettings.tsx
+++ b/src/pages/FeedbackSettings.tsx
@@ -86,27 +86,27 @@ export default function FeedbackSettings() {
 
       let currentProjects = projectsData || [];
 
-      // If no projects exist, create a default project
-      if (currentProjects.length === 0) {
-        const defaultProject = {
-          user_id: user.id,
-          name: 'My Project',
-          project_id: `proj_${Date.now()}` // Generate unique ID
-        };
+              // If no projects exist, create a default project
+        if (currentProjects.length === 0) {
+          const defaultProject = {
+            user_id: user.id,
+            name: 'My Project',
+            project_id: `proj-${Date.now()}` // Generate unique ID
+          };
 
-        const { data: newProject, error: createProjectError } = await supabase
-          .from('projects')
-          .insert(defaultProject)
-          .select()
-          .single();
+          const { data: newProject, error: createProjectError } = await supabase
+            .from('projects')
+            .insert(defaultProject)
+            .select()
+            .single();
 
-        if (createProjectError) {
-          console.error('Error creating default project:', createProjectError);
-          throw createProjectError;
+          if (createProjectError) {
+            console.error('Error creating default project:', createProjectError);
+            throw createProjectError;
+          }
+
+          currentProjects = [newProject];
         }
-
-        currentProjects = [newProject];
-      }
 
       setProjects(currentProjects);
 
@@ -114,11 +114,11 @@ export default function FeedbackSettings() {
         const firstProject = currentProjects[0];
         setSelectedProject(firstProject.id);
 
-        // Load settings for the first project
+        // Load settings for the first project from projects table
         const { data: settingsData, error: settingsError } = await supabase
-          .from('feedback_settings')
-          .select('*')
-          .eq('project_id', firstProject.id)
+          .from('projects')
+          .select('id, user_id, project_id, name, settings')
+          .eq('id', firstProject.id)
           .single();
 
         if (settingsError && settingsError.code !== 'PGRST116') {
@@ -127,29 +127,48 @@ export default function FeedbackSettings() {
         }
 
         if (settingsData) {
-          setSettings(settingsData);
+          // Extract settings from project.settings JSONB field
+          const projectSettings = settingsData.settings || {};
+          const feedbackSettings: FeedbackSettings = {
+            id: settingsData.id,
+            user_id: settingsData.user_id,
+            project_id: settingsData.project_id,
+            widget_title: projectSettings.widget_title || 'We love your feedback!',
+            widget_color: projectSettings.widget_color || '#3B82F6',
+            greeting_text: projectSettings.greeting_text || 'Help us improve by sharing your thoughts',
+            created_at: new Date().toISOString()
+          };
+          setSettings(feedbackSettings);
         } else {
-          // Create default settings
-          const defaultSettings: Omit<FeedbackSettings, 'id' | 'created_at'> = {
-            user_id: user.id,
-            project_id: firstProject.id,
+          // Create default settings in project.settings
+          const defaultSettings = {
             widget_title: 'We love your feedback!',
             widget_color: '#3B82F6',
             greeting_text: 'Help us improve by sharing your thoughts'
           };
 
-          const { data: newSettings, error: createError } = await supabase
-            .from('feedback_settings')
-            .insert(defaultSettings)
+          const { data: updatedProject, error: updateError } = await supabase
+            .from('projects')
+            .update({ settings: defaultSettings })
+            .eq('id', firstProject.id)
             .select()
             .single();
 
-          if (createError) {
-            console.error('Error creating settings:', createError);
-            throw createError;
+          if (updateError) {
+            console.error('Error updating project settings:', updateError);
+            throw updateError;
           }
 
-          setSettings(newSettings);
+          const feedbackSettings: FeedbackSettings = {
+            id: updatedProject.id,
+            user_id: updatedProject.user_id,
+            project_id: updatedProject.project_id,
+            widget_title: defaultSettings.widget_title,
+            widget_color: defaultSettings.widget_color,
+            greeting_text: defaultSettings.greeting_text,
+            created_at: new Date().toISOString()
+          };
+          setSettings(feedbackSettings);
         }
       }
 
@@ -177,41 +196,60 @@ export default function FeedbackSettings() {
 
   const loadProjectSettings = async (projectId: string) => {
     try {
-      const { data: settingsData, error: settingsError } = await supabase
-        .from('feedback_settings')
-        .select('*')
-        .eq('project_id', projectId)
+      const { data: projectData, error: projectError } = await supabase
+        .from('projects')
+        .select('id, user_id, project_id, name, settings')
+        .eq('id', projectId)
         .single();
 
-      if (settingsError && settingsError.code !== 'PGRST116') {
-        console.error('Error loading settings:', settingsError);
-        throw settingsError;
+      if (projectError && projectError.code !== 'PGRST116') {
+        console.error('Error loading project:', projectError);
+        throw projectError;
       }
 
-      if (settingsData) {
-        setSettings(settingsData);
+      if (projectData) {
+        // Extract settings from project.settings JSONB field
+        const projectSettings = projectData.settings || {};
+        const feedbackSettings: FeedbackSettings = {
+          id: projectData.id,
+          user_id: projectData.user_id,
+          project_id: projectData.project_id,
+          widget_title: projectSettings.widget_title || 'We love your feedback!',
+          widget_color: projectSettings.widget_color || '#3B82F6',
+          greeting_text: projectSettings.greeting_text || 'Help us improve by sharing your thoughts',
+          created_at: new Date().toISOString()
+        };
+        setSettings(feedbackSettings);
       } else {
         // Create default settings for this project
-        const defaultSettings: Omit<FeedbackSettings, 'id' | 'created_at'> = {
-          user_id: user.id,
-          project_id: projectId,
+        const defaultSettings = {
           widget_title: 'We love your feedback!',
           widget_color: '#3B82F6',
           greeting_text: 'Help us improve by sharing your thoughts'
         };
 
-        const { data: newSettings, error: createError } = await supabase
-          .from('feedback_settings')
-          .insert(defaultSettings)
+        const { data: updatedProject, error: updateError } = await supabase
+          .from('projects')
+          .update({ settings: defaultSettings })
+          .eq('id', projectId)
           .select()
           .single();
 
-        if (createError) {
-          console.error('Error creating settings:', createError);
-          throw createError;
+        if (updateError) {
+          console.error('Error updating project settings:', updateError);
+          throw updateError;
         }
 
-        setSettings(newSettings);
+        const feedbackSettings: FeedbackSettings = {
+          id: updatedProject.id,
+          user_id: updatedProject.user_id,
+          project_id: updatedProject.project_id,
+          widget_title: defaultSettings.widget_title,
+          widget_color: defaultSettings.widget_color,
+          greeting_text: defaultSettings.greeting_text,
+          created_at: new Date().toISOString()
+        };
+        setSettings(feedbackSettings);
       }
     } catch (error) {
       console.error('Error loading project settings:', error);
@@ -226,13 +264,17 @@ export default function FeedbackSettings() {
     try {
       setSaving(true);
 
+      // Save settings to project.settings JSONB field
+      const settingsToSave = {
+        widget_title: settings.widget_title,
+        widget_color: settings.widget_color,
+        greeting_text: settings.greeting_text
+      };
+
       const { error } = await supabase
-        .from('feedback_settings')
-        .upsert({
-          ...settings,
-          user_id: user.id,
-          project_id: selectedProject
-        });
+        .from('projects')
+        .update({ settings: settingsToSave })
+        .eq('id', selectedProject);
 
       if (error) {
         console.error('Error saving settings:', error);
@@ -258,7 +300,10 @@ export default function FeedbackSettings() {
   const copyEmbedCode = async () => {
     if (!selectedProject) return;
 
-    const embedCode = `<script src="${window.location.origin}/widget.js" data-project-id="${selectedProject}"></script>`;
+    // Get the project_id from the selected project
+    const project = projects.find(p => p.id === selectedProject);
+    const projectId = project?.project_id || selectedProject;
+    const embedCode = `<script src="${window.location.origin}/widget.js" data-project-id="${projectId}"></script>`;
     
     try {
       await navigator.clipboard.writeText(embedCode);
@@ -274,16 +319,21 @@ export default function FeedbackSettings() {
   // Get embed URL
   const getEmbedUrl = () => {
     if (!selectedProject) return '';
-    return `${window.location.origin}/widget.js?project_id=${selectedProject}`;
+    // Get the project_id from the selected project
+    const project = projects.find(p => p.id === selectedProject);
+    return `${window.location.origin}/widget.js?project_id=${project?.project_id || selectedProject}`;
   };
 
   // Get direct form URLs
   const getFormUrls = () => {
     if (!selectedProject) return { satisfaction: '', feedback: '' };
     const baseUrl = window.location.origin;
+    // Get the project_id from the selected project
+    const project = projects.find(p => p.id === selectedProject);
+    const projectId = project?.project_id || selectedProject;
     return {
-      satisfaction: `${baseUrl}/forms/satisfaction?project_id=${selectedProject}`,
-      feedback: `${baseUrl}/forms/feedback?project_id=${selectedProject}`
+      satisfaction: `${baseUrl}/forms/satisfaction?project_id=${projectId}`,
+      feedback: `${baseUrl}/forms/feedback?project_id=${projectId}`
     };
   };
 
@@ -491,7 +541,7 @@ export default function FeedbackSettings() {
                   <Label>Embed Code</Label>
                   <div className="flex items-center space-x-2">
                     <Input
-                      value={`<script src="${getEmbedUrl()}" data-project-id="${selectedProject}"></script>`}
+                      value={`<script src="${getEmbedUrl()}" data-project-id="${projects.find(p => p.id === selectedProject)?.project_id || selectedProject}"></script>`}
                       readOnly
                       className="font-mono text-sm"
                     />
@@ -551,13 +601,13 @@ export default function FeedbackSettings() {
                   <h4 className="font-medium mb-2">API Endpoints</h4>
                   <div className="space-y-2 text-sm font-mono">
                     <div>
-                      <span className="text-blue-600">GET</span> /api/widget/settings/{selectedProject}
+                      <span className="text-blue-600">GET</span> /api/widget/settings/{projects.find(p => p.id === selectedProject)?.project_id || selectedProject}
                     </div>
                     <div>
                       <span className="text-green-600">POST</span> /api/widget/feedback
                     </div>
                     <div>
-                      <span className="text-blue-600">GET</span> /api/feedback/stats/{selectedProject}
+                      <span className="text-blue-600">GET</span> /api/feedback/stats/{projects.find(p => p.id === selectedProject)?.project_id || selectedProject}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Fix Feedback and Feedback Settings pages by aligning them with the actual database schema and using the `projects.settings` JSONB field for settings.

The Feedback page was blank because it was querying a non-existent `feedback` table and incorrect columns. The Feedback Settings page failed because the `feedback_settings` table did not exist; settings are now stored in the `projects` table's `settings` JSONB column.

---
<a href="https://cursor.com/background-agent?bcId=bc-29a32082-c1f4-44d9-ad60-c065538c4494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29a32082-c1f4-44d9-ad60-c065538c4494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

