### PR TITLE
Fix landing and roadmap page visibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,7 @@ const App = () => (
                       <Route path="/insights-simple" element={<DashboardLayout><InsightsSimple /></DashboardLayout>} />
                       <Route path="/reports" element={<DashboardLayout><Reports /></DashboardLayout>} />
                       <Route path="/feedback" element={<DashboardLayout><Feedback /></DashboardLayout>} />
+                      <Route path="/roadmap" element={<DashboardLayout><Roadmap /></DashboardLayout>} />
                       <Route path="/settings" element={<DashboardLayout><Settings /></DashboardLayout>} />
                       <Route path="/teams" element={<DashboardLayout><Teams /></DashboardLayout>} />
                       <Route path="/billing" element={<DashboardLayout><Billing /></DashboardLayout>} />


### PR DESCRIPTION
Add `/roadmap` route to make the Roadmap page accessible and visible in the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-a48f4eba-961b-4842-9b30-50f1ff09ea85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a48f4eba-961b-4842-9b30-50f1ff09ea85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

